### PR TITLE
Only build Docker image on PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,15 +13,16 @@ jobs:
       - run: docker login -u $DOCKER_USER -p $DOCKER_PASS
 
       - run:
-          name: Build and deploy the application image
+          name: Build and deploy the application Docker image
           command: |
             DOCKER_IMAGE=firefoxtesteng/dummy-app-02
             DOCKER_TAG=$CIRCLE_BRANCH
 
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
               DOCKER_TAG="latest"
+              echo "Pushing to ${DOCKER_IMAGE}:${DOCKER_TAG}"
+              docker build -t $DOCKER_IMAGE:$DOCKER_TAG .
+              docker push $DOCKER_IMAGE:$DOCKER_TAG
             fi
 
-            echo "Pushing to ${DOCKER_IMAGE}:${DOCKER_TAG}"
-            docker build -t $DOCKER_IMAGE:$DOCKER_TAG .
-            docker push $DOCKER_IMAGE:$DOCKER_TAG
+


### PR DESCRIPTION
Yeah, the `:latest` stuff now feels a bit hacky and could probably be hardcoded, but this makes it a bit more flexible if we want to revert back to building per-PR instead of only on merge.